### PR TITLE
Fix request body when creating a tree in tests

### DIFF
--- a/server/routes/treeadoptions/treeadoptions.test.js
+++ b/server/routes/treeadoptions/treeadoptions.test.js
@@ -34,10 +34,9 @@ describe('/treesadoptions', () => {
         test('Then confirm the user has not adopted the tree', async () => {
           /** Arrange */
           const treeData = {
-            city: faker.fake(
-              '{{address.cityPrefix}} {{address.cityName}}{{address.citySuffix}}'
-            ),
             common: faker.animal.dog(),
+            scientific: faker.animal.cat(),
+            city: faker.address.cityName(),
             datePlanted: new Date(),
             lat: Number(faker.address.latitude()),
             lng: Number(faker.address.longitude()),
@@ -70,10 +69,9 @@ describe('/treesadoptions', () => {
         test('Then confirm the user has adopted the tree', async () => {
           /** Arrange */
           const treeData = {
-            city: faker.fake(
-              '{{address.cityPrefix}} {{address.cityName}}{{address.citySuffix}}'
-            ),
             common: faker.animal.dog(),
+            scientific: faker.animal.cat(),
+            city: faker.address.cityName(),
             datePlanted: new Date(),
             lat: Number(faker.address.latitude()),
             lng: Number(faker.address.longitude()),
@@ -129,10 +127,9 @@ describe('/treesadoptions', () => {
       test('Then like the tree', async () => {
         /** Arrange */
         const treeData = {
-          city: faker.fake(
-            '{{address.cityPrefix}} {{address.cityName}}{{address.citySuffix}}'
-          ),
           common: faker.animal.dog(),
+          scientific: faker.animal.cat(),
+          city: faker.address.cityName(),
           datePlanted: new Date(),
           lat: Number(faker.address.latitude()),
           lng: Number(faker.address.longitude()),
@@ -186,10 +183,9 @@ describe('/treesadoptions', () => {
       test('Then unadopt the tree', async () => {
         /** Arrange */
         const treeData = {
-          city: faker.fake(
-            '{{address.cityPrefix}} {{address.cityName}}{{address.citySuffix}}'
-          ),
           common: faker.animal.dog(),
+          scientific: faker.animal.cat(),
+          city: faker.address.cityName(),
           datePlanted: new Date(),
           lat: Number(faker.address.latitude()),
           lng: Number(faker.address.longitude()),

--- a/server/routes/treelikes/treelikes.test.js
+++ b/server/routes/treelikes/treelikes.test.js
@@ -34,10 +34,9 @@ describe('/treelikes', () => {
         test('Then confirm the user has not liked the tree', async () => {
           /** Arrange */
           const treeData = {
-            city: faker.fake(
-              '{{address.cityPrefix}} {{address.cityName}}{{address.citySuffix}}'
-            ),
             common: faker.animal.dog(),
+            scientific: faker.animal.cat(),
+            city: faker.address.cityName(),
             datePlanted: new Date(),
             lat: Number(faker.address.latitude()),
             lng: Number(faker.address.longitude()),
@@ -70,10 +69,9 @@ describe('/treelikes', () => {
         test('Then confirm the user has liked the tree', async () => {
           /** Arrange */
           const treeData = {
-            city: faker.fake(
-              '{{address.cityPrefix}} {{address.cityName}}{{address.citySuffix}}'
-            ),
             common: faker.animal.dog(),
+            scientific: faker.animal.cat(),
+            city: faker.address.cityName(),
             datePlanted: new Date(),
             lat: Number(faker.address.latitude()),
             lng: Number(faker.address.longitude()),
@@ -129,10 +127,9 @@ describe('/treelikes', () => {
       test('Then like the tree', async () => {
         /** Arrange */
         const treeData = {
-          city: faker.fake(
-            '{{address.cityPrefix}} {{address.cityName}}{{address.citySuffix}}'
-          ),
           common: faker.animal.dog(),
+          scientific: faker.animal.cat(),
+          city: faker.address.cityName(),
           datePlanted: new Date(),
           lat: Number(faker.address.latitude()),
           lng: Number(faker.address.longitude()),
@@ -183,10 +180,9 @@ describe('/treelikes', () => {
       test('Then unlike the tree', async () => {
         /** Arrange */
         const treeData = {
-          city: faker.fake(
-            '{{address.cityPrefix}} {{address.cityName}}{{address.citySuffix}}'
-          ),
           common: faker.animal.dog(),
+          scientific: faker.animal.cat(),
+          city: faker.address.cityName(),
           datePlanted: new Date(),
           lat: Number(faker.address.latitude()),
           lng: Number(faker.address.longitude()),

--- a/server/routes/treemap/treemap.test.js
+++ b/server/routes/treemap/treemap.test.js
@@ -33,10 +33,9 @@ describe('/api/treemap', () => {
       test('Then the tree cached as GeoJSON', async () => {
         /** Arrange */
         const newTreeData = {
-          city: faker.fake(
-            '{{address.cityPrefix}} {{address.cityName}}{{address.citySuffix}}'
-          ),
           common: faker.animal.dog(),
+          scientific: faker.animal.cat(),
+          city: faker.address.cityName(),
           datePlanted: new Date(),
           lat: Number(faker.address.latitude()),
           lng: Number(faker.address.longitude()),

--- a/server/routes/trees/trees.test.js
+++ b/server/routes/trees/trees.test.js
@@ -34,6 +34,8 @@ describe('/api/trees/:id', () => {
         /** Arrange */
         const body = {
           common: faker.animal.dog(),
+          scientific: faker.animal.cat(),
+          city: faker.address.cityName(),
           datePlanted: new Date(),
           lat: Number(faker.address.latitude()),
           lng: Number(faker.address.longitude()),
@@ -107,12 +109,10 @@ describe('/api/trees/:id', () => {
       describe('When given a new city', () => {
         test('Then create a new tree', async () => {
           /** Arrange */
-          // TODO: determine required inputs when adding a tree
           const body = {
-            city: faker.fake(
-              '{{address.cityPrefix}} {{address.cityName}}{{address.citySuffix}}'
-            ),
             common: faker.animal.dog(),
+            scientific: faker.animal.cat(),
+            city: faker.address.cityName(),
             datePlanted: new Date(),
             lat: Number(faker.address.latitude()),
             lng: Number(faker.address.longitude()),
@@ -151,10 +151,9 @@ describe('/api/trees/:id', () => {
         test("Then create the new city and update it's tree count", async () => {
           /** Arrange */
           const body = {
-            city: faker.fake(
-              '{{address.cityPrefix}} {{address.cityName}}{{address.citySuffix}}'
-            ),
             common: faker.animal.dog(),
+            scientific: faker.animal.cat(),
+            city: faker.address.cityName(),
             datePlanted: new Date(),
             lat: Number(faker.address.latitude()),
             lng: Number(faker.address.longitude()),
@@ -185,14 +184,12 @@ describe('/api/trees/:id', () => {
         test("Then initialize the new tree's history", async () => {
           /** Arrange */
           const body = {
-            city: faker.fake(
-              '{{address.cityPrefix}} {{address.cityName}}{{address.citySuffix}}'
-            ),
             common: faker.animal.dog(),
+            scientific: faker.animal.cat(),
+            city: faker.address.cityName(),
             datePlanted: new Date(),
             lat: Number(faker.address.latitude()),
             lng: Number(faker.address.longitude()),
-            // volunteer: faker.name.findName(), // TODO: volunteer will never end up in treehistory on tree creation
           };
 
           const {
@@ -214,7 +211,7 @@ describe('/api/trees/:id', () => {
                 comment: `THIS ${body.common.toUpperCase()} IS PLANTED!!!`,
                 dateVisit: body.datePlanted.toJSON(),
                 id,
-                idhistory: expect.any(Number),
+                idTreehistory: expect.any(Number),
                 liked: null,
                 mulched: null,
                 pruned: null,
@@ -253,10 +250,9 @@ describe('/api/trees/:id', () => {
       test('Then update the tree', async () => {
         /** Arrange */
         const body = {
-          city: faker.fake(
-            '{{address.cityPrefix}} {{address.cityName}}{{address.citySuffix}}'
-          ),
           common: faker.animal.dog(),
+          scientific: faker.animal.cat(),
+          city: faker.address.cityName(),
           datePlanted: new Date(),
           lat: Number(faker.address.latitude()),
           lng: Number(faker.address.longitude()),


### PR DESCRIPTION
Tests weren't working due to a validation error when creating trees. I added scientific name and city to the request body for creating a tree to fulfill the new requirements.