### PR TITLE
Configure jest to work with ESM

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -3,7 +3,7 @@
  * https://jestjs.io/docs/configuration
  */
 
-module.exports = {
+export default {
   // All imported modules in your tests should be mocked automatically
   // automock: false,
 

--- a/package.json
+++ b/package.json
@@ -64,8 +64,8 @@
   },
   "scripts": {
     "start": "nodemon server/index.js local",
-    "test": "jest",
-    "test:watch": "jest --watch --verbose",
+    "test": "NODE_OPTIONS=--experimental-vm-modules npx jest",
+    "test:watch": "NODE_OPTIONS=--experimental-vm-modules npx jest --watch --verbose",
     "lint": "eslint --ignore-path .gitignore ."
   }
 }


### PR DESCRIPTION
The current Jest configuration stopped working after changing to ESM. I configured the npm scripts that run tests to execute node with --experimental-vm-modules as per the [Jest docs](https://jestjs.io/docs/ecmascript-modules).