### PR TITLE
Fix failing tests

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -6,6 +6,7 @@
       "type": "node",
       "request": "launch",
       "runtimeArgs": [
+        "--experimental-vm-modules",
         "--inspect-brk",
         "${workspaceRoot}/node_modules/.bin/jest",
         "--runInBand"

--- a/server/index.js
+++ b/server/index.js
@@ -1,5 +1,4 @@
 import http from 'http';
-import bodyParser from 'body-parser';
 import compression from 'compression';
 import cors from 'cors';
 import express from 'express';
@@ -8,7 +7,7 @@ import morgan from 'morgan';
 import dotenv from 'dotenv';
 import logger from '../logger.js';
 import unknownEndpointHandler from './middleware/unknown-endpoint-handler.js';
-// import expressErrorHandler from './middleware/express-error-handler.js';
+import expressErrorHandler from './middleware/express-error-handler.js';
 
 import citiesRouter from './routes/cities/cities-router.js';
 import countriesRouter from './routes/countries/countries-router.js';
@@ -71,10 +70,6 @@ app.use(express.json());
 app.use(express.urlencoded({ extended: true }));
 // for logging on command line
 app.use(morgan('dev'));
-// app.use(bodyParser.json());
-// // Retrieve the raw body as a buffer and match all content types
-// app.use(bodyParser.raw({ type: '*/*' }));
-
 app.use(cors(options));
 
 // ROUTES
@@ -93,7 +88,7 @@ app.use('/api/users', usersRouter);
 app.use('/api/usertreehistory', usertreehistoryRouter);
 
 app.use(unknownEndpointHandler);
-// app.use(expressErrorHandler);
+app.use(expressErrorHandler);
 
 const httpServer = http.createServer(app);
 httpServer.listen(port, () => logger.verbose(`${host}:${port}`));

--- a/server/middleware/express-error-handler.js
+++ b/server/middleware/express-error-handler.js
@@ -2,7 +2,7 @@ import logger from '../../logger.js';
 import { pgPromise } from '../db/index.js';
 
 export default function expressErrorHandler(err, req, res, next) {
-  logger.error(`HERE ${err.toString()}`);
+  logger.error(err.toString());
 
   if (err instanceof pgPromise.errors.QueryResultError) {
     res.status(404).json({ error: err.message, treeexists: false });

--- a/server/routes/treemap/treemap.test.js
+++ b/server/routes/treemap/treemap.test.js
@@ -46,34 +46,34 @@ describe('/api/treemap', () => {
         /** Act */
         const params = { city: '%' };
 
-        const treemap = await axiosAPIClient.get('/treemap', {
+        const { status, data } = await axiosAPIClient.get('/treemap', {
           params,
         });
 
+        const expected = { status, data };
+
         /** Assert */
-        expect(treemap).toEqual(
-          expect.objectContaining({
-            status: 200,
-            data: expect.objectContaining({
-              type: 'FeatureCollection',
-              features: expect.arrayContaining([
-                {
-                  id: 'treedata',
-                  type: 'Feature',
-                  geometry: {
-                    type: 'Point',
-                    coordinates: [newTree.data.lng, newTree.data.lat],
-                  },
-                  properties: {
-                    id: newTree.data.id,
-                    common: newTree.data.common,
-                    health: null,
-                  },
+        expect(expected).toMatchObject({
+          status: 200,
+          data: {
+            type: 'FeatureCollection',
+            features: expect.arrayContaining([
+              {
+                id: 'treedata',
+                type: 'Feature',
+                geometry: {
+                  type: 'Point',
+                  coordinates: [newTree.data.lng, newTree.data.lat],
                 },
-              ]),
-            }),
-          }),
-        );
+                properties: {
+                  id: Number(newTree.data.id),
+                  common: newTree.data.common,
+                  health: null,
+                },
+              },
+            ]),
+          },
+        });
       });
     });
   });

--- a/server/routes/trees/trees-queries.js
+++ b/server/routes/trees/trees-queries.js
@@ -15,16 +15,10 @@ export async function createTree(newTreeData) {
   return newTree;
 }
 
-export async function findTreeById(
-  id,
-  id_reference,
-  common,
-  address,
-  source_id,
-) {
-  const query = `SELECT 
-    id, id_reference, 
-    common, scientific, 
+export async function findTreeById(id) {
+  const query = `SELECT
+    id, id_reference,
+    common, scientific, genus,
     address, city, state, zip, country, neighborhood, side_type
     source_id, lng,lat,
     dbh, height, health, water_freq, notes,
@@ -35,10 +29,7 @@ export async function findTreeById(
     FROM treedata
     WHERE id = $1;`;
   const values = [id];
-  const tree = await db
-    .one(query, values)
-    .then((data) => data)
-    .catch((error) => error);
+  const tree = await db.one(query, values);
 
   return tree;
 }

--- a/server/routes/trees/trees-queries.js
+++ b/server/routes/trees/trees-queries.js
@@ -1,4 +1,5 @@
 import { db, pgPromise } from '../../db/index.js';
+import AppError from '../../errors/AppError.js';
 import convertObjectKeysToSnakeCase from '../shared-routes-utils.js';
 
 export async function createTree(newTreeData) {
@@ -29,7 +30,14 @@ export async function findTreeById(id) {
     FROM treedata
     WHERE id = $1;`;
   const values = [id];
-  const tree = await db.one(query, values);
+  const [tree, secondTree] = await db.any(query, values);
+
+  if (secondTree) {
+    throw new AppError(
+      400,
+      `Collision detected! Multiple trees found with the same id, ${id}.`,
+    );
+  }
 
   return tree;
 }

--- a/server/routes/trees/trees-router.js
+++ b/server/routes/trees/trees-router.js
@@ -20,14 +20,12 @@ treesRouter.get('/', async (req, res) => {
     throw new AppError(400, 'Get Tree: Need to send id in query');
   }
   const tree = await findTreeById(id);
-  if (tree.code === 0) {
-    res.status(404).json({ error: 'No data returned from the query.' });
-    return;
-  } else {
+
+  if (tree) {
     tree.healthNum = convertHealthToNumber(tree.health);
-    res.status(200).json(tree);
-    return;
   }
+
+  res.status(200).json(tree ?? {});
 });
 
 treesRouter.post('/', async (req, res) => {

--- a/server/routes/trees/trees-router.js
+++ b/server/routes/trees/trees-router.js
@@ -15,16 +15,15 @@ import convertHealthToNumber from './trees-utils.js';
 const treesRouter = express.Router();
 
 treesRouter.get('/', async (req, res) => {
-  const { id, common, address, sourceId, ref } = req.query;
+  const { id } = req.query;
   if (!id) {
     throw new AppError(400, 'Get Tree: Need to send id in query');
   }
   const tree = await findTreeById(id);
   if (tree.code === 0) {
-    res.status(404).json({ error: 400 });
+    res.status(404).json({ error: 'No data returned from the query.' });
     return;
   } else {
-    // tree.saved = true;
     tree.healthNum = convertHealthToNumber(tree.health);
     res.status(200).json(tree);
     return;
@@ -39,7 +38,6 @@ treesRouter.post('/', async (req, res) => {
       'Post Tree: Missing required parameter(s): common, scientific, city, lat, lng.',
     );
   }
-  const dateplanted = req.body.planted;
   const {
     common,
     scientific,
@@ -61,9 +59,9 @@ treesRouter.post('/', async (req, res) => {
     notes,
     waterFreq,
     irrigation,
+    datePlanted,
     download: url,
     ref: idReference,
-    planted: datePlanted,
     count: locationTreeCount,
   } = req.body;
 

--- a/server/routes/trees/trees.test.js
+++ b/server/routes/trees/trees.test.js
@@ -84,7 +84,7 @@ describe('/api/trees/:id', () => {
     });
 
     describe('When the tree does not exist', () => {
-      test('Then return a 404 status code', async () => {
+      test('Then return an empty object and a 200 status code', async () => {
         /** Arrange */
         const params = { id: 0 };
 
@@ -95,10 +95,41 @@ describe('/api/trees/:id', () => {
 
         /** Assert */
         expect(tree).toMatchObject({
-          status: 404,
-          data: {
-            error: 'No data returned from the query.',
-          },
+          status: 200,
+          data: {},
+        });
+      });
+
+      describe('When a collision is detected (Multiple trees have the same id)', () => {
+        test('Then return a 400 status code', async () => {
+          /** Arrange */
+          const body = {
+            common: faker.animal.dog(),
+            scientific: faker.animal.cat(),
+            city: faker.address.cityName(),
+            datePlanted: new Date(),
+            lat: Number(faker.address.latitude()),
+            lng: Number(faker.address.longitude()),
+          };
+
+          // Create two trees with the same id
+          await axiosAPIClient.post('/trees', body);
+          const {
+            data: { id },
+          } = await axiosAPIClient.post('/trees', body);
+
+          /** Act */
+          const tree = await axiosAPIClient.get('/trees', {
+            params: { id },
+          });
+
+          /** Assert */
+          expect(tree).toMatchObject({
+            status: 400,
+            data: {
+              error: `Collision detected! Multiple trees found with the same id, ${id}.`,
+            },
+          });
         });
       });
     });

--- a/server/routes/trees/trees.test.js
+++ b/server/routes/trees/trees.test.js
@@ -125,7 +125,7 @@ describe('/api/trees/:id', () => {
           expect(newTree).toMatchObject({
             status: 201,
             data: {
-              id: expect.any(Number),
+              id: expect.any(String),
               common: body.common,
               scientific: body.scientific ?? null,
               genus: body.genus ?? null,
@@ -238,7 +238,8 @@ describe('/api/trees/:id', () => {
         expect(newTree).toMatchObject({
           status: 400,
           data: {
-            error: 'Missing required parameter(s).',
+            error:
+              'Post Tree: Missing required parameter(s): common, scientific, city, lat, lng.',
           },
         });
       });


### PR DESCRIPTION
- Add check to throw if found id collisions + test
- Stopped renaming `datePlanted` as `planted` since `datePlanted` is the name of the table column and `planted` is a key returned by the vector tiles
- Uncomment expressErrorHandler to regain central error handler functionality
- Add `--experimental-vm-modules` flag to `launch.json` so that the Jest supports ESModules in the VS Cdde debugger.
- Remove unused and commented code
  - `bodyParser.json()` is made redundant by `express.json()`
  - deleted variables in `trees-router.js` that we not being used