### PR TITLE
Fix ESLint import/no-commonjs issues

### DIFF
--- a/ecosystem.config.js
+++ b/ecosystem.config.js
@@ -1,4 +1,4 @@
-module.exports = {
+export default {
   apps: [
     {
       script: 'server/index.js',

--- a/server/utilities/remove-duplicate-trees.js
+++ b/server/utilities/remove-duplicate-trees.js
@@ -1,6 +1,4 @@
-/* eslint-disable no-restricted-syntax */
-/* eslint-disable camelcase */
-const { db } = require('../db');
+import { db } from '../db/index.js';
 
 const featureFlags = { deleteDups: false };
 

--- a/server/utilities/update-ids.js
+++ b/server/utilities/update-ids.js
@@ -1,6 +1,5 @@
-/* eslint-disable camelcase */
-const { db } = require('../db');
-const { IDForTree } = require('../routes/trees/id');
+import { db } from '../db/index.js';
+import { createIdForTree } from '@waterthetrees/tree-id';
 
 async function findAllTreeIds() {
   const query = `SELECT id_tree AS id_tree, common, scientific, city, lat, lng FROM treedata`;
@@ -17,7 +16,7 @@ async function updateTreeId(id, id_tree) {
 async function findAndReplaceTreeIds() {
   const treeIdRows = await findAllTreeIds();
   for (let i = 0; i < treeIdRows.length; i++) {
-    const id = IDForTree(treeIdRows[i]);
+    const id = createIdForTree(treeIdRows[i]);
     const { id_tree } = treeIdRows[i];
     updateTreeId(id, id_tree);
   }


### PR DESCRIPTION
Fix all warnings under the category `import/no-commonjs`.

List of issues:
- [x] wtt_server/ecosystem.config.js
  - [x] 1:1 warning Expected "export" or "export default" import/no-commonjs
- [x] wtt_server/server/utilities/remove-duplicate-trees.js
  - [x] 3:16 warning Expected "import" instead of "require()" import/no-commonjs
- [x] wtt_server/server/utilities/update-ids.js
  - [x] 2:16 warning Expected "import" instead of "require()" import/no-commonjs
  - [x] 3:23 warning Expected "import" instead of "require()" import/no-commonjs

closes #107