### PR TITLE
Add lint GitHub action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,17 @@
+name: CI
+on: [push, pull_request]
+jobs:
+  ci:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3 # https://github.com/actions/checkout
+      - name: Set up Node
+        uses: actions/setup-node@v3 # https://github.com/actions/setup-node
+        with:
+          node-version-file: package.json
+          cache: npm
+      - name: Install dependencies
+        run: npm ci
+      - name: Lint
+        run: npm run lint


### PR DESCRIPTION
On pushes and pull requests, run `npm run lint`. Will update settings to prevent accepting PRs on failed check after.

Seems to work!
![image](https://user-images.githubusercontent.com/6326660/199139486-f5d02088-59b9-4333-ae8e-2d23a7b3d0ad.png)


Closes #114